### PR TITLE
Change serializing data class to direct serialization, fix tests

### DIFF
--- a/src/main/kotlin/Handler.kt
+++ b/src/main/kotlin/Handler.kt
@@ -1,4 +1,5 @@
 import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler
 import com.google.gson.annotations.SerializedName
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.pichugroup.pichuparkingapi.PichuParkingAPI
@@ -32,35 +33,35 @@ class PichuHandler {
 }
 
 data class APIGatewayEventPayload(
-    @SerializedName("body-json") var body: Map<String, String> = emptyMap(),
-    @SerializedName("params") var params: Parameters = Parameters(),
-    @SerializedName("stage-variables") var stageVariables: Map<String, String> = emptyMap(),
-    @SerializedName("context") var context: APIGatewayEventContext = APIGatewayEventContext(),
+    var body: Map<String, String> = emptyMap(),
+    var params: Parameters = Parameters(),
+    var stageVariables: Map<String, String> = emptyMap(),
+    var context: APIGatewayEventContext = APIGatewayEventContext(),
 )
 
 data class Parameters(
-    @SerializedName("path") var path: Map<String, String> = emptyMap(),
-    @SerializedName("querystring") var queryString: Map<String, String> = emptyMap(),
-    @SerializedName("header") var header: Map<String, String> = emptyMap(),
+    var path: Map<String, String> = emptyMap(),
+    var queryString: Map<String, String> = emptyMap(),
+    var header: Map<String, String> = emptyMap(),
 )
 
 data class APIGatewayEventContext(
-    @SerializedName("account-id") var accountId: String = "",
-    @SerializedName("api-id") var apiId: String = "",
-    @SerializedName("api-key") var apiKey: String = "",
-    @SerializedName("authorizer-principal-id") var authorizerPrincipalId: String = "",
-    @SerializedName("caller") var caller: String = "",
-    @SerializedName("cognito-authentication-provider") var cognitoAuthenticationProvider: String = "",
-    @SerializedName("cognito-authentication-type") var cognitoAuthenticationType: String = "",
-    @SerializedName("cognito-identity-id") var cognitoIdentityId: String = "",
-    @SerializedName("cognito-identity-pool-id") var cognitoIdentityPoolId: String = "",
-    @SerializedName("http-method") var httpMethod: String = "",
-    @SerializedName("stage") var stage: String = "",
-    @SerializedName("source-ip") var sourceIp: String = "",
-    @SerializedName("user") var user: String = "",
-    @SerializedName("user-agent") var userAgent: String = "",
-    @SerializedName("user-arn") var userArn: String = "",
-    @SerializedName("request-id") var requestId: String = "",
-    @SerializedName("resource-id") var resourceId: String = "",
-    @SerializedName("resource-path") var resourcePath: String = "",
+    var accountId: String = "",
+    var apiId: String = "",
+    var apiKey: String = "",
+    var authorizerPrincipalId: String = "",
+    var caller: String = "",
+    var cognitoAuthenticationProvider: String = "",
+    var cognitoAuthenticationType: String = "",
+    var cognitoIdentityId: String = "",
+    var cognitoIdentityPoolId: String = "",
+    var httpMethod: String = "",
+    var stage: String = "",
+    var sourceIp: String = "",
+    var user: String = "",
+    var userAgent: String = "",
+    var userArn: String = "",
+    var requestId: String = "",
+    var resourceId: String = "",
+    var resourcePath: String = "",
 )

--- a/src/main/kotlin/Handler.kt
+++ b/src/main/kotlin/Handler.kt
@@ -34,15 +34,9 @@ class PichuHandler {
 
 data class APIGatewayEventPayload(
     var body: Map<String, String> = emptyMap(),
-    var params: Parameters = Parameters(),
+    var params: Map<String, Map<String, String>> = emptyMap(),
     var stageVariables: Map<String, String> = emptyMap(),
     var context: APIGatewayEventContext = APIGatewayEventContext(),
-)
-
-data class Parameters(
-    var path: Map<String, String> = emptyMap(),
-    var queryString: Map<String, String> = emptyMap(),
-    var header: Map<String, String> = emptyMap(),
 )
 
 data class APIGatewayEventContext(

--- a/src/main/kotlin/org/pichugroup/pichuparkingapi/PichuParkingAPI.kt
+++ b/src/main/kotlin/org/pichugroup/pichuparkingapi/PichuParkingAPI.kt
@@ -5,6 +5,7 @@ import io.github.cdimascio.dotenv.dotenv
 import kotlinx.coroutines.runBlocking
 import org.pichugroup.schema.PichuParkingAPIResponse
 import org.pichugroup.schema.PichuParkingLots
+import org.pichugroup.schema.PichuParkingRates
 import org.pichugroup.thirdpartyparkingapi.*
 import java.time.LocalDateTime
 
@@ -67,11 +68,11 @@ class PichuParkingAPI(private val thirdPartyAPIsToUse: Set<ThirdPartyParkingAPI>
 
     fun getParkingRates(): PichuParkingAPIResponse {
         val currentTime = LocalDateTime.now().toString()
-        val parkingRatesData: MutableSet<PichuParkingLots> = mutableSetOf()
+        val parkingRatesData: MutableSet<PichuParkingRates> = mutableSetOf()
 
         for (api in instantiatedAPIs) {
             runBlocking {
-                val data: Set<PichuParkingLots> = api.getParkingLots()
+                val data: Set<PichuParkingRates> = api.getParkingRates()
                 parkingRatesData.addAll(data)
             }
         }

--- a/src/test/kotlin/org/pichugroup/HandlerTest.kt
+++ b/src/test/kotlin/org/pichugroup/HandlerTest.kt
@@ -6,6 +6,7 @@ import com.google.gson.Gson
 import org.junit.jupiter.api.Test
 import org.pichugroup.schema.PichuParkingAPIResponse
 import org.pichugroup.schema.PichuParkingLots
+import org.pichugroup.schema.PichuParkingRates
 
 class HandlerTest {
     private val handler = PichuHandler()
@@ -14,63 +15,63 @@ class HandlerTest {
     companion object {
         const val parkingLotsPayloadString = """
                                         {
-                                            "body-json": {},
+                                            "body": {},
                                             "params": {
                                                 "path": {},
-                                                "querystring": {},
+                                                "queryString": {},
                                                 "header": {}
                                             },
-                                            "stage-variables": {},
+                                            "stage-stageVariables": {},
                                             "context": {
-                                                "account-id": "your-account-id",
-                                                "api-id": "your-api-id",
-                                                "api-key": "your-api-key",
-                                                "authorizer-principal-id": "your-principal-id",
-                                                "caller": "your-caller",
-                                                "cognito-authentication-provider": "cognito-auth-provider",
-                                                "cognito-authentication-type": "cognito-auth-type",
-                                                "cognito-identity-id": "cognito-identity-id",
-                                                "cognito-identity-pool-id": "cognito-identity-pool-id",
-                                                "http-method": "GET",
-                                                "stage": "your-stage",
-                                                "source-ip": "source-ip",
-                                                "user": "user",
-                                                "user-agent": "user-agent",
-                                                "user-arn": "user-arn",
-                                                "request-id": "request-id",
-                                                "resource-id": "your-resource-id",
-                                                "resource-path": "/parking-lots"
+                                                "accountId" : "186157170780",
+                                                "apiId" : "q7p4ehtedd",
+                                                "apiKey" : "test-invoke-api-key",
+                                                "authorizerPrincipalId" : "",
+                                                "caller" : "186157170780",
+                                                "cognitoAuthenticationProvider" : "",
+                                                "cognitoAuthenticationType" : "",
+                                                "cognitoIdentityId" : "",
+                                                "cognitoIdentityPoolId" : "",
+                                                "httpMethod" : "GET",
+                                                "stage" : "test-invoke-stage",
+                                                "sourceIp" : "test-invoke-source-ip",
+                                                "user" : "186157170780",
+                                                "userAgent" : "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36 Edg/116.0.1938.69",
+                                                "userArn" : "arn:aws:iam::186157170780:root",
+                                                "requestId" : "f9a436db-3b3b-4d25-95b8-cadf929a4e4b",
+                                                "resourceId" : "zv3nht",
+                                                "resourcePath": "/parking-lots"
                                             }
                                         }
                                         """
         const val parkingRatesPayloadString = """
                                         {
-                                            "body-json": {},
+                                            "body": {},
                                             "params": {
                                                 "path": {},
-                                                "querystring": {},
+                                                "queryString": {},
                                                 "header": {}
                                             },
-                                            "stage-variables": {},
+                                            "stage-stageVariables": {},
                                             "context": {
-                                                "account-id": "your-account-id",
-                                                "api-id": "your-api-id",
-                                                "api-key": "your-api-key",
-                                                "authorizer-principal-id": "your-principal-id",
-                                                "caller": "your-caller",
-                                                "cognito-authentication-provider": "cognito-auth-provider",
-                                                "cognito-authentication-type": "cognito-auth-type",
-                                                "cognito-identity-id": "cognito-identity-id",
-                                                "cognito-identity-pool-id": "cognito-identity-pool-id",
-                                                "http-method": "GET",
-                                                "stage": "your-stage",
-                                                "source-ip": "source-ip",
-                                                "user": "user",
-                                                "user-agent": "user-agent",
-                                                "user-arn": "user-arn",
-                                                "request-id": "request-id",
-                                                "resource-id": "your-resource-id",
-                                                "resource-path": "/parking-rates"
+                                                "accountId" : "186157170780",
+                                                "apiId" : "q7p4ehtedd",
+                                                "apiKey" : "test-invoke-api-key",
+                                                "authorizerPrincipalId" : "",
+                                                "caller" : "186157170780",
+                                                "cognitoAuthenticationProvider" : "",
+                                                "cognitoAuthenticationType" : "",
+                                                "cognitoIdentityId" : "",
+                                                "cognitoIdentityPoolId" : "",
+                                                "httpMethod" : "GET",
+                                                "stage" : "test-invoke-stage",
+                                                "sourceIp" : "test-invoke-source-ip",
+                                                "user" : "186157170780",
+                                                "userAgent" : "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36 Edg/116.0.1938.69",
+                                                "userArn" : "arn:aws:iam::186157170780:root",
+                                                "requestId" : "f9a436db-3b3b-4d25-95b8-cadf929a4e4b",
+                                                "resourceId" : "zv3nht",
+                                                "resourcePath": "/parking-rates"
                                             }
                                         }
                                         """
@@ -87,6 +88,6 @@ class HandlerTest {
     fun testGetRequestParkingRates() {
         val eventPayload = gson.fromJson(parkingRatesPayloadString, APIGatewayEventPayload::class.java)
         val response: PichuParkingAPIResponse = handler.handleRequest(event = eventPayload)
-        assert(response.data.elementAt(0) is PichuParkingLots)
+        assert(response.data.elementAt(0) is PichuParkingRates)
     }
 }


### PR DESCRIPTION
AWS does not support custom deserialization, or require more complex implementation. To circumvent this I change the data class to be simpler, and in AWS i will change the mapping template to match this data class.